### PR TITLE
scounter.server 실행 스크립트 개선

### DIFF
--- a/scouter.server/scripts/env.sh
+++ b/scouter.server/scripts/env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+READLINK="`dirname $0`/readlink.sh"
+TUNAHOME="`dirname $($READLINK $0/..)`"
+
+JAVAOPTS="-Xmx512m"
+

--- a/scouter.server/scripts/readlink.sh
+++ b/scouter.server/scripts/readlink.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+TARGET_FILE=$1
+
+cd `dirname $TARGET_FILE`
+TARGET_FILE=`basename $TARGET_FILE`
+
+# Iterate down a (possible) chain of symlinks
+while [ -L "$TARGET_FILE" ]
+do
+    TARGET_FILE=`readlink $TARGET_FILE`
+    cd `dirname $TARGET_FILE`
+    TARGET_FILE=`basename $TARGET_FILE`
+done
+
+# Compute the canonicalized name by finding the physical path
+# for the directory we're in and appending the target file.
+PHYS_DIR=`pwd -P`
+RESULT=$PHYS_DIR/$TARGET_FILE
+echo $RESULT

--- a/scouter.server/scripts/startcon.sh
+++ b/scouter.server/scripts/startcon.sh
@@ -1,1 +1,5 @@
-java -Xmx512m -classpath ./boot.jar scouter.boot.Boot ./lib -console
+#!/usr/bin/env bash
+
+. $(dirname $0)/env.sh
+
+java -Xmx512m -classpath "$TUNAHOME/boot.jar" scouter.boot.Boot "$TUNAHOME/lib" -console

--- a/scouter.server/scripts/startup.sh
+++ b/scouter.server/scripts/startup.sh
@@ -2,7 +2,7 @@
 
 . $(dirname $0)/env.sh
 
-mkdir -p $TUNAHOME/logs > /dev/null 2>&1
+mkdir -p "$TUNAHOME/logs" > /dev/null 2>&1
 cp nohup.out "$TUNAHOME/logs/nohup.$(date '+%Y%m%d%H%M%S').out" > /dev/null 2>&1
 nohup java $JAVAOPTS -classpath "$TUNAHOME/boot.jar" scouter.boot.Boot "$TUNAHOME/lib" > nohup.out &
 

--- a/scouter.server/scripts/startup.sh
+++ b/scouter.server/scripts/startup.sh
@@ -1,5 +1,10 @@
-mkdir logs > /dev/null 2>&1
-cp nohup.out ./logs/nohup.$(date '+%Y%m%d%H%M%S').out > /dev/null 2>&1
-nohup java -Xmx512m -classpath ./boot.jar scouter.boot.Boot ./lib > nohup.out &
+#!/usr/bin/env bash
+
+. $(dirname $0)/env.sh
+
+mkdir -p $TUNAHOME/logs > /dev/null 2>&1
+cp nohup.out "$TUNAHOME/logs/nohup.$(date '+%Y%m%d%H%M%S').out" > /dev/null 2>&1
+nohup java $JAVAOPTS -classpath "$TUNAHOME/boot.jar" scouter.boot.Boot "$TUNAHOME/lib" > nohup.out &
+
 echo "Scouter server launching..."
 echo "See the nohup.out."

--- a/scouter.server/scripts/stop.sh
+++ b/scouter.server/scripts/stop.sh
@@ -1,1 +1,5 @@
-rm -f *.scouter
+#!/usr/bin/env bash
+
+. $(dirname $0)/env.sh
+
+rm -f "$TUNAHOME/*.scouter"


### PR DESCRIPTION
* 실행스크립트가 프로그램이 설치된 절대경로를 기반으로 동작하도록 개선
* 디렉터리명에 공백이 포함되어도 오류가 나지 않도록 개선