### PR TITLE
Edit bucket's position index to have a dependency on current time not 0.

### DIFF
--- a/scouter.common/src/scouter/util/MeteringUtil.java
+++ b/scouter.common/src/scouter/util/MeteringUtil.java
@@ -32,8 +32,8 @@ public abstract class MeteringUtil<T> {
 	public MeteringUtil(int timeUnit, int bucketSize) {
 		this.TIME_UNIT=timeUnit;
 		this.BUCKET_SIZE = bucketSize;
-		this._pos_ = (int) (_time_ % BUCKET_SIZE);
 		this._time_ = getTime();
+		this._pos_ = (int) (_time_ % BUCKET_SIZE);
 		this.table = new Object[bucketSize];
 		for (int i = 0; i < bucketSize; i++) {
 			this.table[i] = create();


### PR DESCRIPTION
Agent가 초기 구동된 후 첫 1초 내에 수집된 metering data는 0번째 bucket에 입력되고 있습니다. 그 이후에는 해당 시간에 맞는 position을 찾아 입력되며, bucket이 환 형태를 갖기 때문에 결국 처음 1초의 데이터가 유실될 가능성이 있습니다.