### PR TITLE
HTTP Header에서 Remote IP Address 조회시 오류 수정

### DIFF
--- a/scouter.agent.java/src/scouter/xtra/http/HttpTrace.java
+++ b/scouter.agent.java/src/scouter/xtra/http/HttpTrace.java
@@ -51,7 +51,8 @@ public class HttpTrace implements IHttpTrace {
 
     public HttpTrace() {
         Configure conf = Configure.getInstance();
-        this.remote_by_header = !StringUtil.isEmpty(conf.trace_http_client_ip_header_key);
+        this.http_remote_ip_header_key = conf.trace_http_client_ip_header_key;
+        this.remote_by_header = !StringUtil.isEmpty(this.http_remote_ip_header_key);
         this.__ip_dummy_test = conf.__ip_dummy_test;
 
         ConfObserver.add(HttpTrace.class.getName(), new Runnable() {
@@ -95,7 +96,6 @@ public class HttpTrace implements IHttpTrace {
         }
 
         ctx.isStaticContents = TraceMain.isStaticContents(ctx.serviceName);
-
 
         ctx.http_method = request.getMethod();
         ctx.http_query = request.getQueryString();
@@ -240,9 +240,15 @@ public class HttpTrace implements IHttpTrace {
             if (__ip_dummy_test) {
                 return getRandomIp();
             }
-
+            
             if (remote_by_header) {
-                return request.getHeader(http_remote_ip_header_key);
+            	String remoteIp = request.getHeader(http_remote_ip_header_key);
+                
+                if (remoteIp != null && remoteIp.indexOf(",") > -1) {
+                	remoteIp = remoteIp.substring(0, remoteIp.indexOf(","));
+                }
+            	
+                return remoteIp;
             } else {
                 return request.getRemoteAddr();
             }


### PR DESCRIPTION
1. java agent의 config 파일에 trace_http_client_ip_header_key 값 설정 후 구동 시 설정된 trace_http_client_ip_header_key 값이 적용되지 않음. (파일 touch 시 적용됨)

2. X-Forwarded-For를 이용하여 HTTP Header로부터 Remote IP Address를 조회 시 둘 이상의 IP 가 반환될 경우 0.0.0.0 으로 처리되며, 경유지의 IP Address를 제외한 가장 첫번째 IP만 반환하도록 수정.