### PR TITLE
bug fix - log files were not removed.

### DIFF
--- a/scouter.agent.java/src/scouter/agent/Logger.java
+++ b/scouter.agent.java/src/scouter/agent/Logger.java
@@ -201,7 +201,7 @@ public class Logger {
 			try {
 				long d = DateUtil.yyyymmdd(date);
 				long fileUnit = DateUtil.getDateUnit(d);
-				if (nowUnit - fileUnit > DateUtil.MILLIS_PER_DAY * conf.log_keep_days) {
+				if (nowUnit - fileUnit > conf.log_keep_days) {
 					files[i].delete();
 				}
 			} catch (Exception e) {


### PR DESCRIPTION
I found that previous scouter log files were not removed. 
Scouter compare DataUnit for file deletion. 
But comparing condition has Big value because it multiply  DateUtil.MILLIS_PER_DAY with conf.log_keep_days.

체크 로직에 일수로 비교하게 되어 있는데 파일 삭제 전 비교 로직에서 conf.log_keep_days와 DateUtil.MILLIS_PER_DAY를 곱하게 되어 있어 정상적으로 scouter 로그 파일이 삭제되지 않는 현상을 발견했습니다. 
수정 후 pull request합니다.
