### PR TITLE
Only PreparedStatement can be checked  "Statement Leak suspected!". Statement is not be checked.

### DIFF
--- a/scouter.agent.java/src/main/java/scouter/agent/asm/JDBCStatementASM.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/asm/JDBCStatementASM.java
@@ -22,7 +22,6 @@ import scouter.org.objectweb.asm.Opcodes;
 import scouter.agent.ClassDesc;
 import scouter.agent.Configure;
 import scouter.agent.Logger;
-import scouter.agent.asm.jdbc.PsInitMV;
 import scouter.agent.asm.jdbc.PsUpdateCountMV;
 import scouter.agent.asm.jdbc.StExecuteMV;
 import scouter.agent.asm.jdbc.StInitMV;

--- a/scouter.agent.java/src/main/java/scouter/agent/asm/JDBCStatementASM.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/asm/JDBCStatementASM.java
@@ -22,8 +22,10 @@ import scouter.org.objectweb.asm.Opcodes;
 import scouter.agent.ClassDesc;
 import scouter.agent.Configure;
 import scouter.agent.Logger;
+import scouter.agent.asm.jdbc.PsInitMV;
 import scouter.agent.asm.jdbc.PsUpdateCountMV;
 import scouter.agent.asm.jdbc.StExecuteMV;
+import scouter.agent.asm.jdbc.StInitMV;
 import scouter.agent.asm.util.HookingSet;
 
 import java.util.HashSet;
@@ -78,7 +80,9 @@ class StatementCV extends ClassVisitor implements Opcodes {
 	@Override
 	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
 		MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-		if (StExecuteMV.isTarget(name)) {
+		if ("<init>".equals(name)) {
+			return new StInitMV(access, desc, mv);
+		}else if (StExecuteMV.isTarget(name)) {
 			if (desc.startsWith("(Ljava/lang/String;)")) {
 				return new StExecuteMV(access, desc, mv, owner, name);
 			}

--- a/scouter.agent.java/src/main/java/scouter/agent/asm/jdbc/StInitMV.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/asm/jdbc/StInitMV.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2015 Scouter Project.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); 
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. 
+ */
+
+package scouter.agent.asm.jdbc;
+
+import scouter.agent.trace.TraceSQL;
+import scouter.org.objectweb.asm.MethodVisitor;
+import scouter.org.objectweb.asm.Opcodes;
+import scouter.org.objectweb.asm.commons.LocalVariablesSorter;
+
+public class StInitMV extends LocalVariablesSorter implements Opcodes {
+	
+	private final static String TRACESQL = TraceSQL.class.getName().replace('.', '/');
+	private final static String METHOD_INIT = "stmtInit";
+	private final static String SIGNATURE_INIT = "(Ljava/lang/Object;)V";
+
+	public StInitMV(int access, String desc, MethodVisitor mv) {
+		super(ASM5,access, desc, mv);
+	}
+
+	@Override
+	public void visitInsn(int opcode) {
+		if (opcode >= IRETURN && opcode <= RETURN) {
+			mv.visitVarInsn(ALOAD, 0);
+			mv.visitMethodInsn(Opcodes.INVOKESTATIC, TRACESQL, METHOD_INIT, SIGNATURE_INIT, false);
+		}
+		mv.visitInsn(opcode);
+	}
+}


### PR DESCRIPTION
Now, only PreparedStaement's "init" method is injected by asm. 
So, when Statement object is not closed, "Statement Leak suspected!" message is not happened.
This request can check "Statement Leak suspected!" when Statement object is not closed.

 