### PR TITLE
SCOUTER Cookie 에 Path 옵션을 지정을 할 수 있도록 지정

### DIFF
--- a/scouter.agent.java/src/main/java/scouter/agent/Configure.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/Configure.java
@@ -182,6 +182,9 @@ public class Configure extends Thread {
     //Trace
     @ConfigDesc("User ID based(0 : Remote Address, 1 : Cookie, 2 : Scouter Cookie, 2 : Header) \n - able to set value for 1.Cookie and 3.Header \n - refer to 'trace_user_session_key'")
     public int trace_user_mode = 2; // 0:Remote IP, 1:JSessionID, 2:Scouter Cookie, 3:Header
+    @ConfigDesc("Setting a cookie path for SCOUTER cookie when trace_user_mode is 2")
+    public String trace_user_cookie_path = "";
+
     @ConfigDesc("Tracing background thread socket")
     public boolean trace_background_socket_enabled = true;
     @ConfigDesc("Adding assigned header value to the service name")
@@ -896,6 +899,7 @@ public class Configure extends Thread {
         this.profile_connection_open_fullstack_enabled = getBoolean("profile_connection_open_fullstack_enabled", false);
         this.profile_connection_autocommit_status_enabled = getBoolean("profile_connection_autocommit_status_enabled", false);
         this.trace_user_mode = getInt("trace_user_mode", 2);
+        this.trace_user_cookie_path = getValue("trace_user_cookie_path", "");
         this.trace_user_session_key = getValue("trace_user_session_key", "JSESSIONID");
         this._trace_auto_service_enabled = getBoolean("_trace_auto_service_enabled", false);
         this._trace_auto_service_backstack_enabled = getBoolean("_trace_auto_service_backstack_enabled", true);

--- a/scouter.agent.java/src/main/java/scouter/xtra/http/HttpTrace.java
+++ b/scouter.agent.java/src/main/java/scouter/xtra/http/HttpTrace.java
@@ -140,7 +140,7 @@ public class HttpTrace implements IHttpTrace {
                     }
                     break;
                 case 2:
-                    ctx.userid = UseridUtil.getUserid(request, response);
+                    ctx.userid = UseridUtil.getUserid(request, response, conf.trace_user_cookie_path);
                     break;
                 case 1:
                     ctx.userid = UseridUtil.getUseridCustom(request, response, conf.trace_user_session_key);

--- a/scouter.agent.java/src/main/java/scouter/xtra/http/UseridUtil.java
+++ b/scouter.agent.java/src/main/java/scouter/xtra/http/UseridUtil.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 public class UseridUtil {
 	private static final String SCOUTE_R = "SCOUTER";
-	public static long getUserid(HttpServletRequest req, HttpServletResponse res) {
+	public static long getUserid(HttpServletRequest req, HttpServletResponse res, String cookiePath) {
 		try {
 			String cookie = req.getHeader("Cookie");
 			if (cookie != null) {
@@ -45,6 +45,9 @@ public class UseridUtil {
 				}
 			}
 			Cookie c = new Cookie(SCOUTE_R, Hexa32.toString32(KeyGen.next()));
+			if ( cookiePath != null && cookiePath.trim().length() > 0 ) {
+				c.setPath(cookiePath);
+			}
 			c.setMaxAge(Integer.MAX_VALUE);
 			res.addCookie(c);
 		} catch (Throwable t) {


### PR DESCRIPTION
https://github.com/scouter-project/scouter/issues/426

이슈에 제기된 문제를 해결하기 위해 Cookie 의 Path 옵션을 trace_user_cookie_path 라는 이름으로 Config를 추가하였습니다. Default 설정은 기존 호환성을 위해 빈 스트링으로 두었습니다.

이를 통해 Path 별 Cookie 가 생성되는 것을 사전에 방지할 수 있게 되었습니다.