### PR TITLE
index_kr.md 파일의 링크 오류 수정

### DIFF
--- a/scouter.document/index_kr.md
+++ b/scouter.document/index_kr.md
@@ -13,7 +13,7 @@
 - [Configuration - options](./main/Configuration_kr.md)
 
 ## How to use
-- [응답시간 분포도(XLog) 보는 방법](../client/Reading-XLog_kr.md)
+- [응답시간 분포도(XLog) 보는 방법](./client/Reading-XLog_kr.md)
 - [NON-HTTP 서비스 추적하기](./use-case/NON-HTTP-Service-Trace_kr.md)
 - [method 상세 프로파일](./use-case/Method-Profiling_kr.md)
 - [Scouter 확장 - Plugin guide](./main/Plugin-Guide_kr.md)


### PR DESCRIPTION
index_kr.md의 "응답시간 분포도(XLog) 보는 방법"에 대한 링크가
"."으로 되어 있어야 할 부분이 ".."으로 되어 있어 404 페이지로 연결 되는 부분 수정 하였습니다.
이번에도 그러면 안되겠지만...혹시 잘못 된 부분이 있다면 알려주세요!!