### PR TITLE
HikariCP 관련 TraceSQL 수정

### DIFF
--- a/scouter.agent.java/src/main/java/scouter/agent/trace/TraceSQL.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/trace/TraceSQL.java
@@ -16,6 +16,9 @@
  */
 package scouter.agent.trace;
 
+import java.lang.reflect.Method;
+import java.util.Properties;
+
 import scouter.agent.Configure;
 import scouter.agent.Logger;
 import scouter.agent.counter.meter.MeterInteraction;
@@ -38,8 +41,6 @@ import scouter.util.IntLinkedSet;
 import scouter.util.StringUtil;
 import scouter.util.SysJMX;
 import scouter.util.ThreadUtil;
-
-import java.lang.reflect.Method;
 
 /**
  * Trace SQL
@@ -549,6 +550,16 @@ public class TraceSQL {
 				Method m = pool.getClass().getMethod("getJdbcUrl", new Class[0]);
 				if (m != null) {
 					String url = (String) m.invoke(pool, new Object[0]);
+					if(url == null) {
+						Method m2 = pool.getClass().getMethod("getDataSourceProperties", new Class[0]);
+						if (m2 != null) {
+							Properties prop =(Properties) m2.invoke(pool, new Object[0]);
+							url = prop.getProperty("url");
+							if(url == null && "".equals(url)){
+								url = prop.getProperty("serverName") + ":" + prop.getProperty("port") + "/" + prop.getProperty("databaseName");
+							}
+						}
+					}
 					String description = "OPEN-DBC " + url + " (" + msg + ")";
 					dbUrl = new DBURL(url, description);
 				}


### PR DESCRIPTION
안녕하세요 스카우터 잘 사용하고 있습니다.
이전 버전(1.9)까지 잘사용하고 있었는데 어제 2.0 버전으로 올리면 
아래의 에러가 나기 시작했습니다. 

CLASS_NAME : HashUtil.java / LINE : 57 / MESSAGE : java.lang.NullPointerException
CLASS_NAME : DataProxy.java / LINE : 74 / MESSAGE : java.lang.NullPointerException

위에 소스를 살펴 보니 저희는 DataSource를 설정할때 아래 처럼(https://github.com/brettwooldridge/HikariCP/wiki/JNDI-DataSource-Factory-(Tomcat,-etc.)
)
jdbcUrl 로 url이 선언 되지 않고  dataSource.url 이나 dataSource.serverName 선언 되어 사용 되었습니다.
그래서 해당 부분을 조금 수정해서 정상 동작하는것으로 확인 했습니다. 

항상 스카우터 잘 사용하고 있습니다 감사합니다.