### PR TITLE
Profile View 내의 Query Parameter 길이제한 조정

### DIFF
--- a/scouter.agent.java/src/main/java/scouter/agent/Configure.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/Configure.java
@@ -261,6 +261,8 @@ public class Configure extends Thread {
     public int _trace_fullstack_socket_open_port = 0;
     @ConfigDesc("")
     public int _trace_sql_parameter_max_count = 128;
+    @ConfigDesc("max length of bound sql parameter on profile view(< 500)")
+    public int trace_sql_parameter_max_length = 20;
     @ConfigDesc("")
     public String trace_delayed_service_mgr_filename = "setting_delayed_service.properties";
     @ConfigDesc("")
@@ -1050,6 +1052,7 @@ public class Configure extends Thread {
         this._profile_fullstack_sql_execute_debug_enabled = getBoolean("_profile_fullstack_sql_execute_debug_enabled", false);
         this._trace_fullstack_socket_open_port = getInt("_trace_fullstack_socket_open_port", 0);
         this._trace_sql_parameter_max_count = getInt("_trace_sql_parameter_max_count", 128);
+        this.trace_sql_parameter_max_length = Math.min(getInt("trace_sql_parameter_max_length", 20), 500);
         this.log_dir = getValue("log_dir", "");
         this.log_rotation_enabled = getBoolean("log_rotation_enabled", true);
         this.log_keep_days = getInt("log_keep_days", 7);

--- a/scouter.agent.java/src/main/java/scouter/agent/trace/TraceSQL.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/trace/TraceSQL.java
@@ -69,7 +69,7 @@ public class TraceSQL {
 		connectionOpenFailException = traceSQL0.getConnectionOpenFailException();
 	}
 
-	public final static int MAX_STRING = 20;
+	private final static int MAX_STRING = conf.trace_sql_parameter_max_length;
 
     // JDBC_REDEFINED==false
     public final static String PSTMT_PARAM_FIELD = "_param_";


### PR DESCRIPTION
관련이슈: #532 

## 기존

고정길이의 20글자 범위 이내에서만 파라미터값 확인 가능.

## 수정

agent.java > `trace_sql_parameter_max_length` 속성을 통해서 500글자 이내로 조정 가능. 
설정값이 500글자 이상으로 세팅되어도 500글자까지만 출력함.