### PR TITLE
[agent.java] with `hook_async_thread_pool_executor_enabled` option, T…

### DIFF
--- a/scouter.agent.java/src/main/java/scouter/agent/trace/TraceContext.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/trace/TraceContext.java
@@ -20,6 +20,7 @@ package scouter.agent.trace;
 import scouter.lang.step.ApiCallStep;
 import scouter.lang.step.DumpStep;
 import scouter.lang.step.SqlStep;
+import scouter.lang.step.ThreadCallPossibleStep;
 import scouter.util.IntKeyMap;
 import scouter.util.SysJMX;
 
@@ -139,6 +140,7 @@ public class TraceContext {
 
 	public SqlStep lastSqlStep;
 	public ApiCallStep lastApiCallStep;
+	public ThreadCallPossibleStep lastThreadCallPossibleStep;
 	public int lastCalleeObjHash;
 	public int lastDbUrl;
 	public String lastRedisConnHost;

--- a/scouter.agent.java/src/main/java/scouter/agent/trace/TraceMain.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/trace/TraceMain.java
@@ -1206,6 +1206,7 @@ public class TraceMain {
             threadCallPossibleStep.hash = DataProxy.sendApicall(threadCallName);
             threadCallPossibleStep.nameTemp = threadCallName;
             ctx.profile.add(threadCallPossibleStep);
+            ctx.lastThreadCallPossibleStep = threadCallPossibleStep;
 
             TransferMap.put(System.identityHashCode(callable), gxid, ctx.txid, callee, ctx.xType, Thread.currentThread().getId(), threadCallPossibleStep);
         } catch (Throwable t) {
@@ -1236,6 +1237,10 @@ public class TraceMain {
             if (ctx == null) return;
             if (callRunnable == null) return;
             if (callRunnable instanceof WrTaskCallable) return;
+            if (ctx.lastThreadCallPossibleStep != null) {
+                ctx.lastThreadCallPossibleStep = null;
+                return;
+            }
 
             if (TransferMap.get(System.identityHashCode(callRunnable)) != null) {
                 return;
@@ -1359,10 +1364,10 @@ public class TraceMain {
             Logger.println("S269", "Hystrix hooking failed. check scouter supporting hystrix version.", e);
         }
 
-        callRunnableInitInvoked(hystrixCommand);
+        callRunnableInitInvoked(hystrixCommand, true);
     }
 
-    public static void callRunnableInitInvoked(Object callRunnableObj) {
+    public static void callRunnableInitInvoked(Object callRunnableObj, boolean addStepToCtx) {
         try {
             TraceContext ctx = TraceContextManager.getContext();
             if (ctx == null) return;
@@ -1387,11 +1392,18 @@ public class TraceMain {
             threadCallPossibleStep.hash = DataProxy.sendApicall(threadCallName);
             threadCallPossibleStep.nameTemp = threadCallName;
             ctx.profile.add(threadCallPossibleStep);
+            if (addStepToCtx) {
+                ctx.lastThreadCallPossibleStep = threadCallPossibleStep;
+            }
 
             TransferMap.put(System.identityHashCode(callRunnableObj), gxid, ctx.txid, callee, ctx.xType, Thread.currentThread().getId(), threadCallPossibleStep);
         } catch (Throwable t) {
             Logger.println("B1203", "Exception: callRunnableInitInvoked", t);
         }
+    }
+
+    public static void callRunnableInitInvoked(Object callRunnableObj) {
+        callRunnableInitInvoked(callRunnableObj, false);
     }
 
     public static Callable wrap1stParamAsWrTaskCallable(Callable callable) {


### PR DESCRIPTION
…here are not double thread steps calling the thread invoked from Spring Async step(or Hystrix Command step) and from ExecutorService any more on a profile.