### PR TITLE
Windows Service Option Scouter Install Example Add

### DIFF
--- a/scouter.document/main/Setup_kr.md
+++ b/scouter.document/main/Setup_kr.md
@@ -102,6 +102,18 @@ JAVA_OPTS=" ${JAVA_OPTS} -Dobj_name=myFirstTomcat1"
   * 위 예에서처럼 -Dscouter.config 환경변수를 통해 conf 파일을 지정할 수 있다.
   * 또한 이 경우 하나의 VM에서 모니터링 대상의 이름이 중복되지 않도록 obj_name 옵션을 통해 이름을 지정하여야 한다.
   
+#### 3.2.2 Java Option example ( Windows Service Option )
+Append below java options in **${TOMCAT_DIR}/bin/tomcat${version}w.exe 
+```bash
+-javaagent:${SCOUTER_INSTALL_DIR}/scouter.agent.jar"
+-Dscouter.config=${SCOUTER_INSTALL_DIR}/conf/scouter1.conf"
+-Dobj_name=myFirstTomcat1"
+```
+* **${SCOUTER_INSTALL_DIR}** means the directory that contains scouter.agent.jar file.
+* **윈도우 서비스를 통해 Tomcat을 실행하는 경우 tomcat${version}w.exe 옵션에 추가해야 한다.**
+  * 해당 옵션은 tomcat${version}w.exe ( ex)tomcat9w.exe ) > Java > Java Options에서 추가할 수 있다.
+  
+  
 ### 3.3. Configuration
 
 #### 3.3.1. Configuration example


### PR DESCRIPTION
Windows Service를 이용해 Scouter를 실행하려는 경우를 추가했습니다.
- 대부분 Linux를 통해 실행하지만 옛날 레거시의 경우 Windows Service 를 통해 실행하는 경우가
많아 해당 경우에 대해 추가하였습니다