### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/scouter.webapp/pom.xml
+++ b/scouter.webapp/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.github.scouter-project</groupId>
         <artifactId>scouter-parent</artifactId>
@@ -80,7 +78,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.8</version>
+            <version>2.12.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
@@ -257,36 +255,36 @@
                         <phase>package</phase>
                         <configuration>
                             <target>
-                                <mkdir dir="${scouter.assembly.working.dir}" />
+                                <mkdir dir="${scouter.assembly.working.dir}"/>
                                 <copy todir="${scouter.assembly.working.dir}">
                                     <fileset dir="${project.basedir}/scripts">
-                                        <include name="**/*" />
+                                        <include name="**/*"/>
                                     </fileset>
                                 </copy>
-                                <copy file="${project.build.directory}/${project.build.finalName}.jar" tofile="${project.build.directory}/${scouter.webapp.jarName}.jar" overwrite="true" verbose="true" />
+                                <copy file="${project.build.directory}/${project.build.finalName}.jar" tofile="${project.build.directory}/${scouter.webapp.jarName}.jar" overwrite="true" verbose="true"/>
 
-                                <fixcrlf srcdir="${scouter.assembly.working.dir}" includes="**/*.sh" eol="lf" eof="remove" />
+                                <fixcrlf srcdir="${scouter.assembly.working.dir}" includes="**/*.sh" eol="lf" eof="remove"/>
                                 <tar destfile="${project.build.directory}/${scouter.webapp.assembly.name}.tar">
                                     <tarfileset dir="${scouter.assembly.working.dir}" mode="755">
-                                        <include name="**/*.sh" />
+                                        <include name="**/*.sh"/>
                                     </tarfileset>
                                     <tarfileset dir="${scouter.assembly.working.dir}">
-                                        <exclude name="**/*.sh" />
+                                        <exclude name="**/*.sh"/>
                                     </tarfileset>
                                     <tarfileset dir="${project.build.directory}">
-                                        <include name="${project.build.finalName}.jar" />
-                                        <include name="${scouter.webapp.jarName}.jar" />
-                                        <include name="lib/**/*" />
+                                        <include name="${project.build.finalName}.jar"/>
+                                        <include name="${scouter.webapp.jarName}.jar"/>
+                                        <include name="lib/**/*"/>
                                     </tarfileset>
                                     <tarfileset dir="${project.basedir}">
-                                        <include name="conf/**/*" />
-                                        <include name="extweb/**/*" />
+                                        <include name="conf/**/*"/>
+                                        <include name="extweb/**/*"/>
                                     </tarfileset>
                                 </tar>
 
                                 <!-- copy for preparing whole packaging -->
-                                <mkdir dir="${scouter.whole.packaging.prepare.dir}" />
-                                <copy file="${project.build.directory}/${scouter.webapp.assembly.name}.tar" todir="${scouter.whole.packaging.prepare.dir}" />
+                                <mkdir dir="${scouter.whole.packaging.prepare.dir}"/>
+                                <copy file="${project.build.directory}/${scouter.webapp.assembly.name}.tar" todir="${scouter.whole.packaging.prepare.dir}"/>
                             </target>
                         </configuration>
                         <goals>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.9.10.8
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.9.10.8 to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS