### PR TITLE
몽고 DB 클래스 생성 오류  버그 픽스

### DIFF
--- a/scouter.agent.java/src/main/java/scouter/agent/asm/mongodb/MongoCommandProtocolASM.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/asm/mongodb/MongoCommandProtocolASM.java
@@ -63,19 +63,12 @@ public class MongoCommandProtocolASM implements IASM, Opcodes {
 
         @Override
         public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-            int newAccess = access;
-            if ((access & Opcodes.ACC_PUBLIC) == 0) {
-                newAccess = access | Opcodes.ACC_PUBLIC;
-            }
-            super.visit(version, newAccess, name, signature, superName, interfaces);
+            super.visit(version, access | ACC_PUBLIC , name, signature, superName, interfaces);
         }
 
         @Override
         public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
-            int newAccess = access;
-            if ((access & Opcodes.ACC_PUBLIC) == 0) {
-                newAccess = access | Opcodes.ACC_PUBLIC;
-            }
+
             if (name.equals("namespace") && descriptor.equals("Lcom/mongodb/MongoNamespace;")) {
                 namespace = true;
             } else if (name.equals("command") && descriptor.equals("Lorg/bson/BsonDocument;")) {
@@ -91,7 +84,8 @@ public class MongoCommandProtocolASM implements IASM, Opcodes {
                     version = V382;
                 }
             }
-            return super.visitField(newAccess, name, descriptor, signature, value);
+
+            return super.visitField(access, name, descriptor, signature, value);
         }
 
         boolean namespace;

--- a/scouter.agent.java/src/main/java/scouter/agent/asm/test/MongoModifyASM.java
+++ b/scouter.agent.java/src/main/java/scouter/agent/asm/test/MongoModifyASM.java
@@ -56,7 +56,6 @@ public class MongoModifyASM implements IASM, Opcodes {
 
 		@Override
 		public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
-			MethodVisitor mv = super.visitMethod(access, methodName, desc, signature, exceptions);
 			int newAccess = access;
 			if ((access & Opcodes.ACC_PUBLIC) == 0) {
 				newAccess = access | Opcodes.ACC_PUBLIC;


### PR DESCRIPTION
2.17.1 몽고 DB 테스트 중에 오류가 발생하여 몽고 DB 어플리케이션이 정상적으로 실행되지 않는 상황이 발생하였습니다.
테스트 수행한 몽고 DB 드라이버 버전은 3.8.0 입니다.

테스트를 jsp와 Spring boot. 두 가지 어플리케이션에서 수행하였습니다.

발생한 에러는 아래와 같이 두 가지 입니다
1. 클래스에 동일 메쏘드가 두 개 생성됨(InternalConnection의 getDescription메소드)
javax.servlet.ServletException: java.lang.ClassFormatError: Duplicate method name "getDescription" with signature "()Lcom.mongodb.connection.ConnectionDescription;" in class file com/mongodb/connection/InternalConnection
	org.apache.jasper.runtime.PageContextImpl.handlePageException(PageContextImpl.java:657)
	org.apache.jsp.gaiatest_005fmongodb_jsp._jspService(gaiatest_005fmongodb_jsp.java:183)
	org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:70)
	javax.servlet.http.HttpServlet.service(HttpServlet.java:764)

2.  illegal field modifiers in class
이 경우는 CommandProtocolImpl.class 파일에 아래와 같은 필드가 있다면
private final MongoNamespace namespace 
클래스변형 후 ==>  public private final  MongoNamespace namespace 로 필드 접근자가 생성되었습니다. 


이 두 가지를 해결한 코드를 pull request 합니다.
혹시나 mongodb 다른 버전의 드라이버에서는 다르게 동작할 수 있으니 확인을 해보시는 걸 권고합니다.