### PR TITLE
Could io.github.scouter-project:scouter-webapp:2.17.1 drop off redundant dependencies?

### DIFF
--- a/scouter.webapp/pom.xml
+++ b/scouter.webapp/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>scouter-server</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                  <artifactId>activation</artifactId>
+                  <groupId>javax.activation</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -59,6 +65,20 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>javax-websocket-server-impl</artifactId>
             <version>${jetty.version}</version>
+            <exclusions>
+                <exclusion>
+                  <artifactId>asm-tree</artifactId>
+                  <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                  <artifactId>asm-commons</artifactId>
+                  <groupId>org.ow2.asm</groupId>
+                </exclusion>
+                <exclusion>
+                  <artifactId>asm</artifactId>
+                  <groupId>org.ow2.asm</groupId>
+                </exclusion>
+             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
@@ -89,6 +109,16 @@
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-bean-validation</artifactId>
             <version>${jersey.version}</version>
+            <exclusions>
+                <exclusion>
+                  <artifactId>jboss-logging</artifactId>
+                  <groupId>org.jboss.logging</groupId>
+                </exclusion>
+                <exclusion>
+                  <artifactId>classmate</artifactId>
+                  <groupId>com.fasterxml</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION

![1](https://user-images.githubusercontent.com/126549527/223321570-a9845b33-5234-4c87-9e4a-985069d64b8c.png)
![2](https://user-images.githubusercontent.com/126549527/223321581-04a2cb38-66ef-4ab2-9d12-e42eec912a15.png)
![3](https://user-images.githubusercontent.com/126549527/223321590-0ed47728-2be4-43f7-b90e-0ec3dd63743b.png)

Hi, I found that **_io.github.scouter-project:scouter-webapp:2.17.1_**’s pom file introduced **_100_** dependencies. However, among them, **_6_** libraries (**_6%_** have not been used by your project), the redundant dependencies are listed below. 

**_6_**  redundant libraries have not been maintained by developers for more than **_3_** years（outdated dependencies）. 

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from outdated dependencies. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding) , and validated that they have not been used by the client code.
 
This PR **_io.github.scouter-project:scouter-webapp:2.17.1_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
      javax.activation:activation:1.1.1:compile [67 KB]
#### Redundant indirect dependencies:
         org.ow2.asm:asm-tree:5.1:compile [28 KB]
         org.jboss.logging:jboss-logging:3.1.3.GA:compile [55 KB]
         com.fasterxml:classmate:1.0.0:compile [58 KB]
         org.ow2.asm:asm-commons:5.1:compile [46 KB]
         org.ow2.asm:asm:5.1:compile [52 KB]  

## Outdated dependencies
org.jboss.logging:jboss-logging:3.1.3.GA ( **_3653_** days without maintenance) 
com.fasterxml:classmate:1.0.0 ( **_3429_** days without maintenance)
org.ow2.asm:asm:5.1 ( **_2558_** days without maintenance) 
 javax.activation:activation:1.1.1 ( **_4882_** days without maintenance)
 org.ow2.asm:asm-tree:5.1  ( **_2558_** days without maintenance)
 org.ow2.asm:asm-commons:5.1  ( **_2558_** days without maintenance)
