### PR TITLE
HiDPI fix

### DIFF
--- a/scouter.client/src/scouter/client/xlog/ImageCache.java
+++ b/scouter.client/src/scouter/client/xlog/ImageCache.java
@@ -61,7 +61,7 @@ public class ImageCache {
 	}
 
 	private Image createXPImage(RGB rgb) {
-		return createXPImage5(rgb);
+		return createXPImage6(rgb);
 	}
 
 	private Image createXPImage4(RGB rgb) {
@@ -94,6 +94,21 @@ public class ImageCache {
 		gcc.drawPoint(4, 1);
 		gcc.drawPoint(0, 3);
 		gcc.drawPoint(3, 4);
+		gcc.dispose();
+		return xp;
+	}
+
+	private Image createXPImage6(RGB rgb) {
+		Image xp;
+		xp = new Image(null, 5, 5);
+		GC gcc = new GC(xp);
+		gcc.setBackground(new Color(null, rgb));
+		gcc.fillRectangle(0, 0, 5, 5);
+		gcc.setBackground(ColorUtil.getInstance().getColor("white"));
+		gcc.fillRectangle(1, 0, 1, 1);
+		gcc.fillRectangle(4, 1, 1, 1);
+		gcc.fillRectangle(0, 3, 1, 1);
+		gcc.fillRectangle(3, 4, 1, 1);
 		gcc.dispose();
 		return xp;
 	}


### PR DESCRIPTION
### Issue
When using XLog in a HiDPI environment with the `-Dswt.autoScale=quarter` option added to the `scouter.ini` file, the graphs appear blurry.
This is because when drawing a point using the `drawPoint` method in a HiDPI environment, the pixel is enlarged to become opaque.

### Solution
The issue has been resolved by modifying the code to draw graphs using rectangles instead of points using the `fillRectangle` method.

### Additional Details
The `-Dswt.autoScale=quarter` option is automatically selects the appropriate HiDPI ratio.
The `drawPoint` method draws individual pixels, which can appear blurry when scaled up.
The `fillRectangle` method draws filled rectangles, which provide a smoother and more consistent appearance in HiDPI environments.

### Blurry XLog
<img width="933" alt="Blurry XLog" src="https://github.com/scouter-project/scouter/assets/19469291/41e785de-8a13-47a8-903d-492296dce63f">

### Clear XLog
<img width="938" alt="Clear XLog" src="https://github.com/scouter-project/scouter/assets/19469291/20535e2d-ff99-4910-b220-e12f535b995c">