### PR TITLE
fixed swagger version by confilicting jackson-databind

### DIFF
--- a/scouter.webapp/pom.xml
+++ b/scouter.webapp/pom.xml
@@ -18,7 +18,7 @@
         <scouter.assembly.working.dir>${project.build.directory}/assembly-working</scouter.assembly.working.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scouter.webapp.jarName>scouter.webapp</scouter.webapp.jarName>
-        <swagger.version>1.5.16</swagger.version>
+        <swagger.version>1.6.14</swagger.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
server version 2.20.0 기준으로 swagger 설정을 on을 해도 화면이 나오지 않는 현상
![image](https://github.com/user-attachments/assets/f9584706-387c-4847-a309-1ff28d938538)
standard alone 으로 확인 해본 결과. swagger bean 생성 시, scan 중에 jackson-databind 라이브러리 때문에 발생 했던것으로 확인
jackson-databind 버전 업에 따라 swagger 도 maven repo 기준으로 최고 버전으로 버전 업